### PR TITLE
Compress et7x00/et8500 kernel

### DIFF
--- a/conf/machine/include/et-nextv-mipsel.inc
+++ b/conf/machine/include/et-nextv-mipsel.inc
@@ -50,7 +50,7 @@ IMAGE_CMD_ubifs_prepend_mipsel = " \
 IMAGE_CMD_ubi_append_mipsel = " \
 	mkdir -p ${IMGDEPLOYDIR}/${IMAGEDIR}; \
 	cp ${IMGDEPLOYDIR}/${IMAGE_NAME}.rootfs.ubi ${IMGDEPLOYDIR}/${IMAGEDIR}/rootfs.bin; \
-	cp ${DEPLOY_DIR_IMAGE}/vmlinux-${MACHINE}.bin ${IMGDEPLOYDIR}/${IMAGEDIR}/kernel.bin; \
+	gzip -9c ${DEPLOY_DIR_IMAGE}/vmlinux-${MACHINE}.bin > ${IMGDEPLOYDIR}/${IMAGEDIR}/kernel.bin; \
 	echo "${IMAGEVERSION}" > ${IMGDEPLOYDIR}/${IMAGEDIR}/imageversion; \
 	echo "rename this file to 'force' to force an update without confirmation" > ${IMGDEPLOYDIR}/${IMAGEDIR}/noforce; \
 	cd ${IMGDEPLOYDIR}; \


### PR DESCRIPTION
as otherwise it's too big.
This was removed in an previous commit.