### PR TITLE
et10000: rename v3d-nxpl -> v3d-mipsel

### DIFF
--- a/conf/machine/et10000.conf
+++ b/conf/machine/et10000.conf
@@ -2,7 +2,7 @@
 #@NAME: et10000
 #@DESCRIPTION: Machine configuration for the et10000
 
-MACHINE_FEATURES += " wifi-kernel4 dvb-c transcoding v3d-nxpl"
+MACHINE_FEATURES += " wifi-kernel4 dvb-c transcoding v3d-mipsel"
 OPENPLI_FEATURES += " ci kodi"
 DISTRO_FEATURES_remove = "x11 wayland directfb"
 

--- a/conf/machine/include/et-essential.inc
+++ b/conf/machine/include/et-essential.inc
@@ -1,7 +1,7 @@
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS = "\
 	kernel-module-cdfs \
-	${@bb.utils.contains('MACHINE_FEATURES', 'v3d-nxpl', 'et-v3ddriver-${MACHINE}' , '', d)} \
+	${@bb.utils.contains('MACHINE_FEATURES', 'v3d-mipsel', 'et-v3ddriver-${MACHINE}' , '', d)} \
 	${@bb.utils.contains('MACHINE_FEATURES', 'micom', 'et-fpupdate-${MACHINE}' , '', d)} \
 	\
 	${@bb.utils.contains('MACHINE_FEATURES', 'wifi-kernel4', 'firmware-rtl8192eu firmware-rtl8188eu firmware-rtl8xxxu firmware-mt7601u kernel-module-rtl88x2bu kernel-module-r8188eu kernel-module-8192eu kernel-module-mt7601u kernel-module-rtl8xxxu' , '', d)} \

--- a/conf/machine/include/et-mipsel.inc
+++ b/conf/machine/include/et-mipsel.inc
@@ -39,9 +39,6 @@ DVBMEDIASINK_CONFIG_mipsel = "--with-wma --with-wmv --with-pcm --with-dts --with
 	${@bb.utils.contains('MACHINE_FEATURES', 'h265', '--with-h265 --with-vb6 --with-vb8 --with-spark' , '', d)} \
 	"
 
-EXTRA_OECONF_append_pn-kodi = " --with-gpu=v3d"
-EXTRA_OECMAKE_append_pn-kodi += " -DWITH_V3D=nxpl"
-
 IMAGEVERSION := "${DISTRO_NAME}-${DISTRO_VERSION}-${DATE}"
 IMAGEVERSION[vardepsexclude] = "DATE"
 


### PR DESCRIPTION
for kodi, use the same naming as in OE-A and OpenPLi

 while there remove EXTRA_OECMAKE_append_pn-kodi
 in kodi > 18 this is now unnecessary in the machine conf files,
 it is derived from MACHINE_FEATURES

Signed-off-by: Andrea Adami <andrea.adami@gmail.com>